### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ In any tmux mode:
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:
 
-    set -g @tpm_plugins "          \
-      tmux-plugins/tpm             \
-      jbnicolai/tmux-fpp           \
-    "
+    set -g @plugin 'jbnicolai/tmux-fpp'
 
 Hit `prefix + I` to fetch the plugin and source it. You should now be able to
 use the plugin.


### PR DESCRIPTION
Using `set -g @tpm_plugins` is deprecated. See https://github.com/tmux-plugins/tpm#installation.

Thanks for the plugin @jbnicolai! :)
