### PR TITLE
Remove the temp buffer even if fpp "fails"

### DIFF
--- a/fpp.tmux
+++ b/fpp.tmux
@@ -15,5 +15,5 @@ readonly key="$(get_tmux_option "@fpp-key" "f")"
 
 tmux bind-key "$key" capture-pane \\\; \
     save-buffer /tmp/tmux-buffer \\\; \
-    new-window -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp && rm /tmp/tmux-buffer'"
+    new-window -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp ; rm /tmp/tmux-buffer'"
 


### PR DESCRIPTION
With '&&' in the shell script calling `fpp`, the temporary buffer is not deleted if `fpp` fails for some reason.
';' seems to me like it should be preferred.
