### PR TITLE
Set a helpful window name

### DIFF
--- a/fpp.tmux
+++ b/fpp.tmux
@@ -15,5 +15,5 @@ readonly key="$(get_tmux_option "@fpp-key" "f")"
 
 tmux bind-key "$key" capture-pane \\\; \
     save-buffer /tmp/tmux-buffer \\\; \
-    new-window -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp && rm /tmp/tmux-buffer'"
+    new-window -n fpp -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp && rm /tmp/tmux-buffer'"
 


### PR DESCRIPTION
Something minor really: currently the window name is 'sh'. 'fpp' looks more helpful.
