### PR TITLE
Unwrap lines before calling `fpp`

### DIFF
--- a/fpp.tmux
+++ b/fpp.tmux
@@ -13,7 +13,7 @@ get_tmux_option() {
 
 readonly key="$(get_tmux_option "@fpp-key" "f")"
 
-tmux bind-key "$key" capture-pane \\\; \
+tmux bind-key "$key" capture-pane -J \\\; \
     save-buffer /tmp/tmux-buffer \\\; \
     new-window -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp && rm /tmp/tmux-buffer'"
 


### PR DESCRIPTION
tmux-fpp fails to correctly detect line-wrapped file names and may truncate the
file names.
Using the -J flag lets tmux join wrapped lines when capturing the pane
contents.

From the `tmux` man page section on `capture-pane`:

```
-J joins wrapped lines and preserves trailing spaces at each line's end.
```

PS: this looks an awful lot like tmux-plugins/tmux-urlview#1 ;-)
