### PR TITLE
Clear buffer after dumping to disk

### DIFF
--- a/fpp.tmux
+++ b/fpp.tmux
@@ -15,5 +15,6 @@ readonly key="$(get_tmux_option "@fpp-key" "f")"
 
 tmux bind-key "$key" capture-pane \\\; \
     save-buffer /tmp/tmux-buffer \\\; \
+    delete-buffer \\\; \
     new-window -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp && rm /tmp/tmux-buffer'"
 


### PR DESCRIPTION
The tmux buffer created by `capture-pane` lingers on after it has been
dumped to the disk for `fpp`.
It should be removed to prevent polluting the user's list of buffers.
