### PR TITLE
Use $TMPDIR for temp directory

### DIFF
--- a/fpp.tmux
+++ b/fpp.tmux
@@ -14,6 +14,6 @@ get_tmux_option() {
 readonly key="$(get_tmux_option "@fpp-key" "f")"
 
 tmux bind-key "$key" capture-pane \\\; \
-    save-buffer /tmp/tmux-buffer \\\; \
-    new-window -c "#{pane_current_path}" "sh -c 'cat /tmp/tmux-buffer | fpp && rm /tmp/tmux-buffer'"
+    save-buffer "${TMPDIR:-/tmp}/tmux-buffer" \\\; \
+    new-window -c "#{pane_current_path}" "sh -c 'cat \"${TMPDIR:-/tmp}/tmux-buffer\" | fpp && rm \"${TMPDIR:-/tmp}/tmux-buffer\"'"
 


### PR DESCRIPTION
The TMPDIR environment variable should be honored if set, as it may point to
something other than `/tmp` (e.g. `/tmp/.private/$(whoami)` on my system).
Fallback to `/tmp` if `$TMPDIR` is unset or empty.
