### PR TITLE
Add tmux note to keybinding for list-keys

### DIFF
--- a/fpp.tmux
+++ b/fpp.tmux
@@ -56,7 +56,7 @@ tmux_fpp_init() {
   mode="$(tmux show-option -gqv @fpp-mode)" || true
   : "${mode:=edit}"
 
-  tmux bind-key "${key}" run-shell "$(printf '%q start %q' "${BASH_SOURCE[0]}" "${mode}")"
+  tmux bind-key -N "Facebook Path Picker" "${key}" run-shell "$(printf '%q start %q' "${BASH_SOURCE[0]}" "${mode}")"
 }
 
 # Save the buffer contents and create a new window for running FPP.


### PR DESCRIPTION
This PR simply adds a -N note so that the chosen key binding appears in `tmux list-keys` / `<prefix> + ?` and "Describe key binding" `<prefix> + /`, which is useful when you have a lot of custom keybindings.