### PR TITLE
Add @fpp-history-limit setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ bind-key x run-shell '~/.tmux/plugins/tmux-fpp/fpp.tmux start paste'
 
 Put `set -g @fpp-path '~/my/path/fpp'` in `tmux.conf`.
 
+> How can I make fpp search my pane history and not just the current screen?
+
+Put `set -g @fpp-history-limit '50000'` in `tmux.conf`.
+
 ### Other goodies
 
 `tmux-fpp` works great with:


### PR DESCRIPTION
Allows the user to specify if only the current pane's contents are used as input, or if the scrollback history should be also used. The current behavior is maintained as the default.

The implementation is the same as in https://github.com/wfxr/tmux-fzf-url, with its `@fzf-url-history-limit` variable.

Fixes #30 